### PR TITLE
Add smoke test for data-redis using Lettuce Redis driver.

### DIFF
--- a/data/data-redis/README.adoc
+++ b/data/data-redis/README.adoc
@@ -1,0 +1,1 @@
+Tests if Data Redis with Lettuce is working.

--- a/data/data-redis/build.gradle
+++ b/data/data-redis/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+	id "java"
+	id "org.springframework.boot"
+	id "org.springframework.cr.smoke-test"
+}
+
+dependencies {
+	implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+	implementation("org.crac:crac:$cracVersion")
+	implementation(project(":cr-listener"))
+
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+	appTestImplementation(project(":cr-smoke-test-support"))
+	appTestImplementation("org.awaitility:awaitility:4.2.0")
+}
+
+crSmokeTest {
+	webApplication = false
+
+}

--- a/data/data-redis/docker-compose.yml
+++ b/data/data-redis/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.1'
+services:
+  redis:
+    image: 'redis:7'
+    ports:
+      - '6379'

--- a/data/data-redis/src/appTest/java/com/example/data/redis/DataRedisApplicationTests.java
+++ b/data/data-redis/src/appTest/java/com/example/data/redis/DataRedisApplicationTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.redis;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Duration;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.cr.smoketest.support.assertj.AssertableOutput;
+import org.springframework.cr.smoketest.support.junit.ApplicationTest;
+
+/**
+ * @author Christoph Strobl
+ */
+@ApplicationTest
+public class DataRedisApplicationTests {
+
+	@Test
+	void connectionTest(AssertableOutput output) {
+		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+			assertThat(output).hasLineMatching("Starting RedisReader: was (initialized|stopped)");
+			assertThat(output).hasLineMatching("RedisReader: counting [0-9\\.]+");
+		});
+	}
+
+}

--- a/data/data-redis/src/main/java/com/example/data/redis/DataRedisApplication.java
+++ b/data/data-redis/src/main/java/com/example/data/redis/DataRedisApplication.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.redis;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author Christoph Strobl
+ */
+@SpringBootApplication
+public class DataRedisApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(DataRedisApplication.class, args);
+	}
+
+}

--- a/data/data-redis/src/main/java/com/example/data/redis/RedisReader.java
+++ b/data/data-redis/src/main/java/com/example/data/redis/RedisReader.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.redis;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.springframework.context.SmartLifecycle;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Christoph Strobl
+ */
+@Component
+@EnableScheduling
+class RedisReader implements SmartLifecycle {
+
+	static final String STATE_KEY = "component-state";
+	static final String COUNTER_KEY = "counter";
+
+	final StringRedisTemplate redisTemplate;
+
+	final AtomicBoolean running = new AtomicBoolean(false);
+
+	RedisReader(StringRedisTemplate redisTemplate) {
+
+		this.redisTemplate = redisTemplate;
+		this.redisTemplate.delete(COUNTER_KEY);
+		this.redisTemplate.opsForValue().set(STATE_KEY, "initialized");
+	}
+
+	@Override
+	public void start() {
+
+		if (running.compareAndSet(false, true)) {
+			String previousState = getSetState("started");
+			System.out.println("Starting RedisReader: was %s".formatted(previousState));
+		}
+	}
+
+	@Scheduled(fixedDelay = 1000)
+	public void scheduled() {
+
+		if (isRunning()) {
+			Long value = redisTemplate.opsForValue().increment(COUNTER_KEY);
+			System.out.println("RedisReader: counting %s".formatted(value));
+		}
+	}
+
+	@Override
+	public void stop() {
+
+		if (running.compareAndSet(true, false)) {
+			String previousState = getSetState("stopped");
+			System.out.println("Stopping RedisReader: was %s".formatted(previousState));
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return running.get();
+	}
+
+	String getSetState(String newState) {
+		return redisTemplate.opsForValue().getAndSet(STATE_KEY, newState);
+	}
+
+}

--- a/data/data-redis/src/main/resources/application.properties
+++ b/data/data-redis/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT_6379:6379}
+logging.level.DefaultLifecycleProcessor.CracResourceAdapter.afterRestore=INFO
+logging.level.org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory=TRACE

--- a/data/data-redis/src/main/resources/application.properties
+++ b/data/data-redis/src/main/resources/application.properties
@@ -1,4 +1,3 @@
 spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT_6379:6379}
-logging.level.DefaultLifecycleProcessor.CracResourceAdapter.afterRestore=INFO
 logging.level.org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory=TRACE

--- a/data/data-redis/src/test/java/com/example/data/redis/RedisTemplateTest.java
+++ b/data/data-redis/src/test/java/com/example/data/redis/RedisTemplateTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.redis;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+/**
+ * @author Christoph Strobl
+ */
+@SpringBootTest
+public class RedisTemplateTest {
+
+	@Test
+	void templateWorks(@Autowired StringRedisTemplate template) {
+		assertThat(template.getConnectionFactory().getConnection().ping()).isEqualTo("PONG");
+	}
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,7 +27,7 @@ rootProject.name="spring-checkpoint-restore-smoke-tests"
 include "cr-smoke-test-support"
 include "cr-listener"
 
-["framework", "integration"].each { group ->
+["data", "framework", "integration"].each { group ->
 	file(group).eachDirMatch(~/[a-z].*/) { smokeTest ->
 		include "$group:${smokeTest.name}"
 	}


### PR DESCRIPTION
This PR adds a smoke test using data-redis and the Lettuce Redis driver. 

Due to my chip architecture spinning up docker within the `dev-container` did not go as expected which caused failures. However testing against a Redis instance running on the docker host using `host.docker.internal` worked once no `docker-compose.yml` is present. So please drop the first commit on merge.

Also had to extend `AwaitApplication` to cover a restored application.  