### PR TITLE
Add data-elasticsearch smoke test

### DIFF
--- a/data/data-elasticsearch/README.adoc
+++ b/data/data-elasticsearch/README.adoc
@@ -1,0 +1,1 @@
+Tests if Data Elasticsearch with REST client is working.

--- a/data/data-elasticsearch/build.gradle
+++ b/data/data-elasticsearch/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id "java"
+    id "org.springframework.boot"
+    id "org.springframework.cr.smoke-test"
+}
+
+dependencies {
+    implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
+    implementation("org.springframework.boot:spring-boot-starter-data-elasticsearch")
+
+    implementation("org.crac:crac:$cracVersion")
+    implementation(project(":cr-listener"))
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    appTestImplementation(project(":cr-smoke-test-support"))
+    appTestImplementation("org.awaitility:awaitility:4.2.0")
+}
+
+crSmokeTest {
+    webApplication = false
+}

--- a/data/data-elasticsearch/docker-compose.yml
+++ b/data/data-elasticsearch/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.1'
+services:
+  elasticsearch:
+    image: 'elasticsearch:8.8.0'
+    container_name: 'elasticsearch'
+    ports:
+      - '9200'
+      - '9300'
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false

--- a/data/data-elasticsearch/src/appTest/java/com/example/data/elasticsearch/DataElasticsearchApplicationTests.java
+++ b/data/data-elasticsearch/src/appTest/java/com/example/data/elasticsearch/DataElasticsearchApplicationTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.elasticsearch;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Duration;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.cr.smoketest.support.assertj.AssertableOutput;
+import org.springframework.cr.smoketest.support.junit.ApplicationTest;
+
+@ApplicationTest
+public class DataElasticsearchApplicationTests {
+
+	@Test
+	void connectionTest(AssertableOutput output) {
+		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+			assertThat(output).hasLineMatching("Starting ElasticsearchReader: was (initialized|stopped)");
+			assertThat(output).hasLineContaining("You Know, for Search");
+		});
+	}
+
+}

--- a/data/data-elasticsearch/src/main/java/com/example/data/elasticsearch/ApplicationState.java
+++ b/data/data-elasticsearch/src/main/java/com/example/data/elasticsearch/ApplicationState.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.data.elasticsearch;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+@Document(indexName = "smoke-test-index")
+class ApplicationState {
+
+	@Id
+	private String applicationId;
+
+	private String state;
+
+	public ApplicationState() {
+	}
+
+	public ApplicationState(String id, String state) {
+		this.applicationId = id;
+		this.state = state;
+	}
+
+	public String getApplicationId() {
+		return applicationId;
+	}
+
+	public void setApplicationId(String applicationId) {
+		this.applicationId = applicationId;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public void setName(String state) {
+		this.state = state;
+	}
+
+	ApplicationState newState(String state) {
+		return new ApplicationState(this.applicationId, state);
+	}
+
+}

--- a/data/data-elasticsearch/src/main/java/com/example/data/elasticsearch/ApplicationStateRepository.java
+++ b/data/data-elasticsearch/src/main/java/com/example/data/elasticsearch/ApplicationStateRepository.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.data.elasticsearch;
+
+import org.springframework.data.repository.CrudRepository;
+
+interface ApplicationStateRepository extends CrudRepository<ApplicationState, String> {
+
+}

--- a/data/data-elasticsearch/src/main/java/com/example/data/elasticsearch/DataElasticsearchApplication.java
+++ b/data/data-elasticsearch/src/main/java/com/example/data/elasticsearch/DataElasticsearchApplication.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.elasticsearch;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DataElasticsearchApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(DataElasticsearchApplication.class, args);
+	}
+
+}

--- a/data/data-elasticsearch/src/main/java/com/example/data/elasticsearch/ElasticsearchReader.java
+++ b/data/data-elasticsearch/src/main/java/com/example/data/elasticsearch/ElasticsearchReader.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.elasticsearch;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.springframework.context.SmartLifecycle;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ClassUtils;
+
+@Component
+@EnableScheduling
+public class ElasticsearchReader implements SmartLifecycle {
+
+	private final ApplicationStateRepository applicationStateRepository;
+
+	private final ElasticsearchTemplate elasticsearchOperations;
+
+	final AtomicBoolean running = new AtomicBoolean(false);
+
+	public ElasticsearchReader(ApplicationStateRepository applicationStateRepository,
+			ElasticsearchTemplate elasticsearchOperations) {
+
+		this.applicationStateRepository = applicationStateRepository;
+		this.applicationStateRepository
+			.save(new ApplicationState(ClassUtils.getShortName(ElasticsearchReader.class), "initialized"));
+		this.elasticsearchOperations = elasticsearchOperations;
+	}
+
+	@Override
+	public void start() {
+		if (running.compareAndSet(false, true)) {
+			ApplicationState previousState = getSetState("started");
+			System.out.println("Starting ElasticsearchReader: was %s".formatted(previousState.getState()));
+		}
+	}
+
+	@Scheduled(fixedDelay = 1000)
+	public void scheduled() {
+
+		if (isRunning()) {
+			String tagline = elasticsearchOperations.execute(client -> client.info().tagline());
+			System.out.println(tagline);
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (running.compareAndSet(true, false)) {
+			ApplicationState previousState = getSetState("stopped");
+			System.out.println("Stopping ElasticsearchReader: was %s".formatted(previousState.getState()));
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return running.get();
+	}
+
+	ApplicationState getSetState(String newState) {
+
+		ApplicationState current = applicationStateRepository
+			.findById(ClassUtils.getShortName(ElasticsearchReader.class))
+			.orElseThrow(() -> new IllegalStateException("Expected ElasticsearchReader to be initialized"));
+		applicationStateRepository.save(current.newState(newState));
+		return current;
+	}
+
+}

--- a/data/data-elasticsearch/src/main/resources/application.properties
+++ b/data/data-elasticsearch/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.elasticsearch.uris=http://${ELASTICSEARCH_HOST:localhost}:${ELASTICSEARCH_PORT_9200:9200}


### PR DESCRIPTION
Currently failing due to open sockets in the `PoolingNHttpClientConnectionManager` used by the `CloseableHttpAsyncClient`.

We'd need to close all pooled connections (`closeExpiredConnections` &  `closeIdleConnections`) in the `PoolingNHttpClientConnectionManager` and then restart the the `httpAsyncClient` on restore.. Or close the entire client and recreate it from scratch on startup.
