### PR TITLE
Increase logging level for Spring Pulsar reactive app

### DIFF
--- a/integration/spring-pulsar-reactive/src/main/resources/application.properties
+++ b/integration/spring-pulsar-reactive/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.pulsar.admin.service-url=http://${PULSAR_HOST:localhost}:${PULSAR_PORT_80
 spring.pulsar.consumer.subscription.initial-position=earliest
 
 logging.level.root=INFO
-logging.level.org.apache.pulsar=WARN
+logging.level.org.apache.pulsar=DEBUG
 logging.level.org.apache.pulsar.common.util.netty.DnsResolverUtil=ERROR
 logging.level.org.springframework.pulsar=DEBUG
 logging.level.org.springframework.pulsar.function=WARN


### PR DESCRIPTION
The Spring for Apache Pulsar reactive app test is taking > 20s to restore and is therefore getting killed. 

This increases the logging level to `DEBUG` for Pulsar and Spring Pulsar in an effort to understand where it is taking so long. Of course it works 100% of the time locally. 😢 